### PR TITLE
fix label “for” for contact form email address field

### DIFF
--- a/includes/blocks/class-contact-form.php
+++ b/includes/blocks/class-contact-form.php
@@ -211,7 +211,7 @@ class Contact_Form {
 			</p>
 
 			<p>
-				<label for="contact-name">
+				<label for="contact-email">
 					Email address
 					<?php \CTCL\Elections\Helpers::error_message( $errors, 'email' ); ?>
 				</label>


### PR DESCRIPTION
Fixes #167